### PR TITLE
Clean up dependencies.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,6 @@ poly1305 = "0.6.2"
 rand = { version="0.8.3", features = ["small_rng"] }
 rand_core = "0.6.3"
 seahash = "4.1.0"
-criterion = "0.3.1"
-rayon = "1.5.0"
 lazy_static = "1.4.0"
 base64 = "0.13"
 serde = {version="1.0", features=["derive"]}
@@ -24,6 +22,7 @@ clap = "2.34.0"
 bincode = "1.3.3"
 
 [dev-dependencies]
+criterion = "0.3.1"
 pi-rs-cli-utils = {path = "./pi-rs-cli-utils"}
 
 [[bench]]


### PR DESCRIPTION
The `criterion` crate is only used for benchmarking and can be declared a development-only dependency.

The `rayon` crate is no longer used.