### PR TITLE
Update poly1305 to 0.8.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2018"
 bitreader = "0.3.3"
 hex-literal = "0.3.1"
 libmath = "0.2.1"
-poly1305 = "0.6.2"
+poly1305 = "0.8.0"
 rand = { version="0.8.3", features = ["small_rng"] }
 rand_core = "0.6.3"
 seahash = "4.1.0"


### PR DESCRIPTION
Update the `poly1305` depedency crate to the latest release to address `cargo audit` warnings about obsolete depedences.

API looks like it's backward-compatible for our use; builds and passes tests.