### PR TITLE
Bump criterion to 0.5.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ clap = "2.34.0"
 bincode = "1.3.3"
 
 [dev-dependencies]
-criterion = "0.3.1"
+criterion = "0.5.1"
 pi-rs-cli-utils = {path = "./pi-rs-cli-utils"}
 
 [[bench]]


### PR DESCRIPTION
Update to the latest version of the `criterion` benchmark framework to address `cargo audit` warnings about unsound and obsolete transitive dependencies.

This raises the MSRV quite a bit to 1.64, at least for developers.