### PR TITLE
Update pi-rs-cli-utils to clap 4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,6 @@ lazy_static = "1.4.0"
 base64 = "0.13"
 serde = {version="1.0", features=["derive"]}
 serde_json = "1.0.59"
-clap = "2.34.0"
 bincode = "1.3.3"
 
 [dev-dependencies]

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -8,7 +8,7 @@ const BENCH_DB_GEN: bool = true;
 
 fn criterion_benchmark(c: &mut Criterion) {
   let CLIFlags {
-    m,
+    matrix_height,
     lwe_dim,
     ele_size,
     plaintext_bits,
@@ -17,9 +17,9 @@ fn criterion_benchmark(c: &mut Criterion) {
   let mut lwe_group = c.benchmark_group("lwe");
 
   println!("Setting up DB for benchmarking. This might take a while...");
-  let db_eles = bench_utils::generate_db_eles(m, (ele_size + 7) / 8);
+  let db_eles = bench_utils::generate_db_eles(matrix_height, (ele_size + 7) / 8);
   let shard =
-    Shard::from_base64_strings(&db_eles, lwe_dim, m, ele_size, plaintext_bits)
+    Shard::from_base64_strings(&db_eles, lwe_dim, matrix_height, ele_size, plaintext_bits)
       .unwrap();
   println!("Setup complete, starting benchmarks");
   if BENCH_ONLINE {

--- a/pi-rs-cli-utils/Cargo.toml
+++ b/pi-rs-cli-utils/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "pi-rs-cli-utils"
-version = "0.0.1"
+version = "0.1.0"
+description = "Private Information Retrieval example"
 edition = "2018"
 
 [dependencies]
-clap = "2.34.0"
+clap = { version = "4.3.1", features = ["derive"] }

--- a/pi-rs-cli-utils/src/lib.rs
+++ b/pi-rs-cli-utils/src/lib.rs
@@ -1,87 +1,43 @@
-use clap::{App, Arg};
+use clap::{Parser, arg};
 use std::env;
+use std::num::ParseIntError;
 
+#[derive(Parser)]
+/// Flags for setting PIR parameters
 pub struct CLIFlags {
-  pub m: usize,
+  /// Log2 of height of DB matrix
+  #[arg(short, long, default_value_t = 16, value_parser = parse_exp_to_usize)]
+  pub matrix_height: usize,
+  /// LWE dimension
+  #[arg(short = 'd', long = "dim", default_value_t = 2048)]
   pub lwe_dim: usize,
+  /// Number of plaintext bits encoded in each entry of DB matrix
+  #[arg(short, long, default_value_t = 10)]
   pub plaintext_bits: usize,
+  /// Log2 of element bit length
+  #[arg(short, long, default_value_t = 13, value_parser = parse_exp_to_usize)]
   pub ele_size: usize,
 }
 
 pub fn parse_cli_flags() -> CLIFlags {
-  let matches = App::new("PIR example")
-    .version("0.0.1")
-    .author("Alex Davidson <coela@alxdavids.xyz>")
-    .about("Flags for setting PIR parameters")
-    .arg(
-      Arg::with_name("matrix_height")
-        .short("m")
-        .long("matrix_height")
-        .takes_value(true)
-        .default_value("16")
-        .help("Log2 of height of DB matrix"),
-    )
-    .arg(
-      Arg::with_name("ele_size")
-        .short("e")
-        .long("ele_size")
-        .takes_value(true)
-        .default_value("13")
-        .help("Log2 of element bit length"),
-    )
-    .arg(
-      Arg::with_name("plaintext_bits")
-        .short("p")
-        .long("plaintext_bits")
-        .takes_value(true)
-        .default_value("10")
-        .help("Number of plaintext bits encoded in each entry of DB matrix"),
-    )
-    .arg(
-      Arg::with_name("dim")
-        .short("d")
-        .long("dim")
-        .takes_value(true)
-        .default_value("2048")
-        .help("LWE dimension"),
-    )
-    .get_matches();
-
-  let ele_size =
-    parse_exp_to_usize(String::from(matches.value_of("ele_size").unwrap()));
-  let lwe_dim: usize = String::from(matches.value_of("dim").unwrap())
-    .parse()
-    .unwrap();
-  let plaintext_bits: usize =
-    String::from(matches.value_of("plaintext_bits").unwrap())
-      .parse()
-      .unwrap();
-  let m = parse_exp_to_usize(String::from(
-    matches.value_of("matrix_height").unwrap(),
-  ));
-  CLIFlags {
-    m,
-    lwe_dim,
-    plaintext_bits,
-    ele_size,
-  }
+    CLIFlags::parse()
 }
 
 pub fn parse_from_env() -> CLIFlags {
-  let ele_size = parse_exp_to_usize(env::var("PIR_ELE_SIZE_EXP").unwrap());
+  let ele_size = parse_exp_to_usize(&env::var("PIR_ELE_SIZE_EXP").unwrap()).unwrap();
   let lwe_dim: usize = env::var("PIR_LWE_DIM").unwrap().parse().unwrap();
   let plaintext_bits: usize =
     env::var("PIR_PLAINTEXT_BITS").unwrap().parse().unwrap();
-  let m = parse_exp_to_usize(env::var("PIR_MATRIX_HEIGHT_EXP").unwrap());
+  let matrix_height = parse_exp_to_usize(&env::var("PIR_MATRIX_HEIGHT_EXP").unwrap()).unwrap();
   CLIFlags {
-    m,
+    matrix_height,
     lwe_dim,
     plaintext_bits,
     ele_size,
   }
 }
 
-pub fn parse_exp_to_usize(v: String) -> usize {
-  let exp: u32 = v.parse().unwrap();
-  2_u32.pow(exp) as usize
+fn parse_exp_to_usize(v: &str) -> Result<usize, ParseIntError> {
+  let exp: u32 = v.parse()?;
+  Ok(2_u32.pow(exp) as usize)
 }


### PR DESCRIPTION
Address unsound and unmaintaned `cargo audit` warnings about transitive dependencies by updating the latest release of the command-line argument parsing crate. This involves porting to the new api. Switch to the `derive` interface to shorted the implementation code.

Remove unused direct dependency on `clap` in the top-level crate.