### PR TITLE
Remove unused dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,14 +7,8 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bitreader = "0.3.3"
-hex-literal = "0.3.1"
-libmath = "0.2.1"
-poly1305 = "0.8.0"
 rand = { version="0.8.3", features = ["small_rng"] }
 rand_core = "0.6.3"
-seahash = "4.1.0"
-lazy_static = "1.4.0"
 base64 = "0.13"
 serde = {version="1.0", features=["derive"]}
 serde_json = "1.0.59"


### PR DESCRIPTION
To reduce the code size we want to remove all unused dependencies. [cargo-udeps](https://github.com/est31/cargo-udeps) can be used to identify unused dependencies. 